### PR TITLE
Fix minor error

### DIFF
--- a/plugins/_ChatActions.py
+++ b/plugins/_ChatActions.py
@@ -136,7 +136,7 @@ async def ChatActionsHandler(ult):  # sourcery no-metrics
 
 @ultroid_bot.on(events.NewMessage(incoming=True))
 async def chatBot_replies(event):
-    if event.sender_id and chatbot_stats(event.chat.id, event.sender_id) and event.text:
+    if event.sender_id and chatbot_stats(event.chat_id, event.sender_id) and event.text:
         msg = get_chatbot_reply(event, event.text)
         if msg:
             await event.reply(msg)

--- a/plugins/_ChatActions.py
+++ b/plugins/_ChatActions.py
@@ -136,7 +136,7 @@ async def ChatActionsHandler(ult):  # sourcery no-metrics
 
 @ultroid_bot.on(events.NewMessage(incoming=True))
 async def chatBot_replies(event):
-    if event.sender_id and chatbot_stats(event.chat_id, event.sender_id) and event.text:
+    if event.sender_id and chatbot_stats(event.chat_id, event.sender_id) and not event.media:
         msg = get_chatbot_reply(event, event.text)
         if msg:
             await event.reply(msg)

--- a/plugins/stickertools.py
+++ b/plugins/stickertools.py
@@ -40,7 +40,7 @@ from os import remove
 import cv2
 import numpy as np
 from PIL import Image, ImageDraw
-from telethon import utils
+from telethon.utils import get_input_document
 from telethon.errors import ChatSendStickersForbiddenError, PackShortNameOccupiedError
 from telethon.tl.types import (
     DocumentAttributeFilename,
@@ -158,7 +158,7 @@ async def pack_kangish(_):
         )
         stiks = []
         for i in _get_stiks.documents:
-            x = utils.get_input_document(i)
+            x = get_input_document(i)
             stiks.append(
                 types.InputStickerSetItem(
                     document=x,


### PR DESCRIPTION
> `chat`
> Returns the User, Chat or Channel where this object belongs to. It may be None if Telegram didn’t send the chat.
> 
> If you only need the ID, use chat_id instead.
Source: https://docs.telethon.dev/en/latest/modules/custom.html#telethon.tl.custom.chatgetter.ChatGetter

So sometimes telegram does't send chat object with `NewMessage` event that raises exception.
So it's better to use this approach.