### PR TITLE
allow tag logger to notify you even on edited messages

### DIFF
--- a/plugins/_chatactions.py
+++ b/plugins/_chatactions.py
@@ -156,6 +156,7 @@ async def ChatActionsHandler(ult):  # sourcery no-metrics
 
 
 @ultroid_bot.on(events.NewMessage(incoming=True))
+@ultroid_bot.on(events.MessageEdited(incoming=True))
 async def chatBot_replies(e):
     sender = await e.get_sender()
     if not isinstance(sender, types.User):


### PR DESCRIPTION
official telegram applications do not notify if any user edits a message with your username.

this pull request attempts to patch the existing functionality to also include edited messages