### PR TITLE
Fix AttributeError with Pillow>=10: Downgrade to Pillow 9.3 for 'text…

### DIFF
--- a/resources/startup/optional-requirements.txt
+++ b/resources/startup/optional-requirements.txt
@@ -17,7 +17,7 @@ lxml
 numpy>=1.21.2
 oauth2client
 opencv-python-headless
-pillow>=7.0.0
+pillow==9.3
 profanitydetector
 psutil
 pypdf2>=1.26.0


### PR DESCRIPTION
…size' Compatibility

as latest version of pillow causing problem of 
AttributeError: 'ImageDraw' object has no attribute 'textsize' downgrading the version of pillow to 9.3 fixes the problem