### PR TITLE
Update CodeQL workflow to use latest CLI binaries and cache database

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,13 +19,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Cache CodeQL database
+        uses: actions/cache@v2
+        with:
+          path: ~/.codeql
+          key: ${{ runner.os }}-codeql-${{ hashFiles('**/qlpack.yml') }}
+          restore-keys: ${{ runner.os }}-codeql-
+
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: 'python'
-          tools: github/codeql-cli-binaries@v2.15.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
-        with:
-          tools: github/codeql-cli-binaries@v2.15.3
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: CodeQL Analysis
 
 on:
   push:
-    # ignore dependabot branches on push -> https://github.com/microsoft/binskim/issues/425#issuecomment-893373709
     branches-ignore:
       - 'dependabot/**'
   pull_request:
+    branches: [ '**' ]
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
@@ -14,6 +14,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -21,7 +22,10 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:
-          languages: python
+          languages: 'python'
+          tools: github/codeql-cli-binaries@v2.15.3
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
+        with:
+          tools: github/codeql-cli-binaries@v2.15.3


### PR DESCRIPTION
Update CodeQL workflow to use latest CLI binaries and cache database

- Specify the use of the latest CodeQL CLI binaries version v2.15.3 for both initialization and analysis steps.