### PR TITLE
Fix Gemini model loading from database dynamically

### DIFF
--- a/plugins/aiwrapper.py
+++ b/plugins/aiwrapper.py
@@ -36,7 +36,7 @@ import asyncio
 ENDPOINTS = {
     "gpt": "https://api.openai.com/v1/chat/completions",
     "antr": "https://api.anthropic.com/v1/messages",
-    "gemini": "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent",
+    "gemini": "https://generativelanguage.googleapis.com/v1/models/",
     "deepseek": "https://api.deepseek.com/chat/completions"
 }
 
@@ -163,6 +163,7 @@ async def get_ai_response(provider, prompt, api_key, stream=False):
                                 continue
 
         elif provider == "gemini":
+            endpoint = f"{ENDPOINTS[provider]}{model}:generateContent"
             params = {"key": api_key}
             data = {
                 "contents": [{
@@ -170,7 +171,7 @@ async def get_ai_response(provider, prompt, api_key, stream=False):
                 }]
             }
             response = await async_searcher(
-                ENDPOINTS[provider],
+                endpoint,
                 params=params,
                 headers=headers,
                 post=True,


### PR DESCRIPTION
This PR fixes the issue where the Gemini model specified in the database (via GEMINI_MODEL) was not used in the API call due to a hardcoded endpoint. The endpoint is now dynamically constructed using the model name from the database, allowing custom models like `gemini-2.0-flash` to work correctly.

Changes:
- Updated ENDPOINTS["gemini"] to a base URL.
- Modified get_ai_response to construct the Gemini endpoint with the model name.
