### PR TITLE
Update channelhacks.py - change in shift command

### DIFF
--- a/plugins/channelhacks.py
+++ b/plugins/channelhacks.py
@@ -60,7 +60,7 @@ async def _(e):
         LOGS.exception(er)
         await z.edit(get_string("cha_1"))
         return
-    async for msg in e.client.iter_messages(int(c), reverse=True):
+    async for msg in e.client.iter_messages(int(c), reverse=True, limit=None):
         try:
             await asyncio.sleep(2)
             await e.client.send_message(int(d), msg)


### PR DESCRIPTION
Added limit type none in the shift command. By default, it is restricted to sending id 0 to 100. By adding limit = none, that limit is bypassed