### PR TITLE
Add Redis keepalive task, fix Qovery Redis env parsing, and bump version

### DIFF
--- a/pyUltroid/__main__.py
+++ b/pyUltroid/__main__.py
@@ -18,6 +18,7 @@ def main():
         WasItRestart,
         autopilot,
         customize,
+        keep_redis_alive,
         plug,
         ready,
         startup_stuff,
@@ -49,6 +50,7 @@ def main():
     LOGS.info("Initialising...")
 
     ultroid_bot.run_in_loop(autopilot())
+    ultroid_bot.loop.create_task(keep_redis_alive())
 
     pmbot = udB.get_key("PMBOT")
     manager = udB.get_key("MANAGER")

--- a/pyUltroid/startup/_database.py
+++ b/pyUltroid/startup/_database.py
@@ -274,11 +274,11 @@ class RedisDB(_BaseDatabase):
         if platform.lower() == "qovery" and not host:
             var, hash_, host, password = "", "", "", ""
             for vars_ in os.environ:
-                if vars_.startswith("QOVERY_REDIS_") and vars.endswith("_HOST"):
+                if vars_.startswith("QOVERY_REDIS_") and vars_.endswith("_HOST"):
                     var = vars_
             if var:
                 hash_ = var.split("_", maxsplit=2)[1].split("_")[0]
-            if hash:
+            if hash_:
                 kwargs["host"] = os.environ.get(f"QOVERY_REDIS_{hash_}_HOST")
                 kwargs["port"] = os.environ.get(f"QOVERY_REDIS_{hash_}_PORT")
                 kwargs["password"] = os.environ.get(f"QOVERY_REDIS_{hash_}_PASSWORD")

--- a/pyUltroid/startup/funcs.py
+++ b/pyUltroid/startup/funcs.py
@@ -10,6 +10,7 @@ import os
 import random
 import shutil
 import time
+from datetime import datetime, timezone as dt_timezone
 from random import randint
 
 from ..configs import Var
@@ -47,6 +48,8 @@ from .. import LOGS, ULTConfig
 from ..fns.helper import download_file, inline_mention, updater
 
 db_url = 0
+REDIS_KEEPALIVE_KEY = "KEEP_ACTIVE"
+REDIS_KEEPALIVE_INTERVAL_SECONDS = 7 * 24 * 60 * 60
 
 
 async def autoupdate_local_database():
@@ -150,6 +153,33 @@ async def startup_stuff():
             )
             os.environ["TZ"] = "UTC"
             time.tzset()
+
+
+async def keep_redis_alive():
+    from .. import udB
+
+    if udB.name != "Redis":
+        return
+
+    interval = udB.get_key("REDIS_KEEPALIVE_INTERVAL")
+    try:
+        interval = int(interval) if interval else REDIS_KEEPALIVE_INTERVAL_SECONDS
+    except (TypeError, ValueError):
+        interval = REDIS_KEEPALIVE_INTERVAL_SECONDS
+    interval = max(interval, 60)
+
+    while True:
+        try:
+            now = datetime.now(dt_timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+            udB.set_key(REDIS_KEEPALIVE_KEY, f"Updated value at {now}")
+            LOGS.debug(
+                "Redis keepalive updated key '%s' (next run in %s seconds).",
+                REDIS_KEEPALIVE_KEY,
+                interval,
+            )
+        except Exception as exc:
+            LOGS.warning("Redis keepalive update failed: %s", exc)
+        await asyncio.sleep(interval)
 
 
 async def autobot():

--- a/pyUltroid/version.py
+++ b/pyUltroid/version.py
@@ -1,2 +1,2 @@
-__version__ = "2025.05.31"
-ultroid_version = "2.1.1"
+__version__ = "2026.04.03"
+ultroid_version = "2.1.2"


### PR DESCRIPTION
### Motivation

- Prevent managed/free Redis instances from being marked inactive by periodically touching a key.
- Fix Qovery Redis environment variable parsing so Redis can initialize correctly on that platform.
- Start the keepalive mechanism automatically on bot startup/restart.
- Reflect the change with a version bump.

### Description

- Added `keep_redis_alive()` in `pyUltroid/startup/funcs.py`:
  - runs only when current DB backend is Redis
  - writes key `KEEP_ACTIVE` with a UTC timestamp value
  - uses `REDIS_KEEPALIVE_INTERVAL` if set, otherwise defaults to 7 days
  - enforces a minimum interval of 60 seconds
- Wired startup scheduling in `pyUltroid/__main__.py` via:
  - importing `keep_redis_alive`
  - `ultroid_bot.loop.create_task(keep_redis_alive())` after startup init
- Fixed Qovery env parsing bugs in `pyUltroid/startup/_database.py`:
  - `vars` → `vars_`
  - `vars_.endswith("_HOST")`
  - `if hash_:` (instead of undefined `hash`)
- Bumped `pyUltroid/version.py`:
  - `__version__ = "2026.04.03"`
  - `ultroid_version = "2.1.2"`

### Testing

- `python -m compileall pyUltroid`